### PR TITLE
fix syntax error.

### DIFF
--- a/plugin/alpaca_tags.vim
+++ b/plugin/alpaca_tags.vim
@@ -49,7 +49,7 @@ endif
 if !exists('g:alpaca_tags_ctags_bin')
   if executable('/Applications/MacVim.app/Contents/MacOS/ctags')
     let g:alpaca_tags_ctags_bin = '/Applications/MacVim.app/Contents/MacOS/ctags'
-  elseif
+  else
     let g:alpaca_tags_ctags_bin = 'ctags'
   endif
 endif


### PR DESCRIPTION
コードリーディングの時にとても便利に使わせていただいています。

Bundle で alpaca-tc/alpaca_tags をインストールしようとして、
スクリプトの一部で文法エラーが出ているようです。
### 手順
1. .vimrc に「Bundle 'alpaca-tc/alpaca_tags'」を追記。
2. :BundleInstall 実行
3. エラーが出る

```
/home/kaishuu0123/.vim/bundle/alpaca_tags/plugin/alpaca_tags.vim の処理中にエラーが検出されました:
行   52:
E15: 無効な式です:
E15: 無効な式です:
```

elseif で何かを書きたかったのかもしれませんが、とりあえずエラーをなくすということで PR 送ります。
