### PR TITLE
Fix initialize variable 'g:alpaca_tags_config'

### DIFF
--- a/plugin/alpaca_tags.vim
+++ b/plugin/alpaca_tags.vim
@@ -58,6 +58,7 @@ if !exists('g:alpaca_tags_ctags_bin')
 endif
 
 let g:alpaca_tags_disable = get(g:, 'alpaca_tags_disable', 0)
+let g:alpaca_tags_config = get(g:, 'alpaca_tags_config', {})
 
 let g:alpaca_tags_root_dir = expand("<sfile>:p:h:h")
 command! -nargs=* -complete=customlist,alpaca_tags#create_tags#complete_source


### PR DESCRIPTION
READMEに書いてあるのは承知ですが、`g:alpaca_tags_config`がvimrc等で未定義だとエラーが出るのが気になりました

（`echoerr`や`echomsg`でもいいかとは思ったのですが…）
#### エラーメッセージ例

```
"Gemfile" 15L, 268C 書込み
function alpaca_tags#create_tags#update_bundle..<SNR>242_get_tags_options..<SNR>242_get_tags_option_by の処理中にエラーが検出されました:
行    1:
E121: 未定義の変数です: g:alpaca_tags_config
E116: 関数の無効な引数です: has_key(g:alpaca_tags_config, a:key)
E15: 無効な式です: has_key(g:alpaca_tags_config, a:key)
E121: 未定義の変数です: g:alpaca_tags_config
E116: 関数の無効な引数です: has_key(g:alpaca_tags_config, a:key)
E15: 無効な式です: has_key(g:alpaca_tags_config, a:key)
```

お気に召さなかったらrejectしてください :bow:
