### PR TITLE
Fix order of ctags options

### DIFF
--- a/bin/create_bundle_tags_into_git
+++ b/bin/create_bundle_tags_into_git
@@ -16,5 +16,5 @@ done
 
 if [ -d "${git_root_dir}" ]; then
   cd ${git_root_dir}
-  bundle show --paths | xargs ${ctags_path} ${ctags_args} -R -f ${git_root_dir}/.git/gem.tags
+  bundle show --paths | xargs ${ctags_path} -f ${git_root_dir}/.git/gem.tags ${ctags_args} -R
 fi

--- a/bin/create_tags_into_git
+++ b/bin/create_tags_into_git
@@ -14,6 +14,6 @@ done
 
 git_root_dir=`git rev-parse --show-toplevel`
 if [ -d "${git_root_dir}" ]; then
-  echo "${ctags_path} ${ctags_args} -f ${git_root_dir}/.git/working_dir.tags ${git_root_dir}"
-  ${ctags_path} ${ctags_args} -f ${git_root_dir}/.git/working_dir.tags ${git_root_dir}
+  echo "${ctags_path} -f ${git_root_dir}/.git/working_dir.tags ${ctags_args} ${git_root_dir}"
+  ${ctags_path} -f ${git_root_dir}/.git/working_dir.tags ${ctags_args} ${git_root_dir}
 fi


### PR DESCRIPTION
Ubuntu 12.04 LTSに含まれるctags（Exuberant Ctags）でタグファイルが出力できませんでした。
-fオプションの順番を入れ替えることで正常に動作するよう修正しました。
