### PR TITLE
Add a new feature to kill a process with a too large tag file

### DIFF
--- a/autoload/alpaca_tags/process_manager.vim
+++ b/autoload/alpaca_tags/process_manager.vim
@@ -33,6 +33,11 @@ function! s:check_status() "{{{
       continue
     end
 
+    if s:is_over_max_filesize(process.tag_builder.tempname())
+      call alpaca_tags#process_manager#kill(path)
+      continue
+    endif
+
     if status == 'active'
       call process.in_process()
     elseif status == 'inactive'
@@ -43,6 +48,12 @@ function! s:check_status() "{{{
     endif
   endfor
 endfunction"}}}
+
+function! s:is_over_max_filesize(path)
+  let max_filesize = get(g:, 'alpaca_tags#max_filesize', 0)
+  let actual_filesize = getfsize(a:path)
+  return max_filesize && max_filesize < actual_filesize
+endfunction
 
 function! s:start_watching() "{{{
   if exists('s:loaded_start_watching')

--- a/autoload/alpaca_tags/process_manager.vim
+++ b/autoload/alpaca_tags/process_manager.vim
@@ -52,6 +52,9 @@ function! s:start_watching() "{{{
 
   augroup AlpacaTagsWatching
     autocmd!
+    if get(g:, 'alpaca_tags#enable_status_check_on_cursormoved', 0)
+      autocmd CursorMoved,CursorMovedI * call s:check_status()
+    endif
     autocmd CursorHold,CursorHoldI * call s:check_status()
     autocmd VimLeavePre * call alpaca_tags#process_manager#reset()
   augroup END

--- a/doc/alpaca_tags.txt
+++ b/doc/alpaca_tags.txt
@@ -169,6 +169,12 @@ g:alpaca_tags#single_task                                *g:alpaca_tags#single_t
 g:alpaca_tags#timeout_period                                *g:alpaca_tags#timeout_period*
                 If it is 60, alpaca_tags will kill process in 60 seconds.
 
+g:alpaca_tags#max_filesize                                *g:alpaca_tags#max_filesize*
+                If it is 1073741824(1GB), alpaca_tags will kill process with a large file over the max size.
+
+g:alpaca_tags#enable_status_check_on_cursormoved                                *g:alpaca_tags#enable_status_check_on_cursormoved*
+                If it is 1, alpaca_tags will check the status of processes on moving a cursor.
+
 g:alpaca_tags#console                                 *g:alpaca_tags#console*
                 NOTE This variable is options for debugger.
 >


### PR DESCRIPTION
I've added a new feature to kill a process with a too large tag file so that we can avoid running out of disk spaces. This case occurs when running `AlpacaTagsUpdate` at the root of a directory including files that could generate a too large `tags` file. For example, parsing https://github.com/ashtuchkin/iconv-lite/blob/v0.2.11/encodings/table/gbk.js by ctags generates millions of lines.

As you know, we can kill processes by setting `g:alpaca_tags#timeout_period` to a small value, but I want to manage them by filesize.

Moreover, I've added new settings like below.

* Set `g:alpaca_tags#enable_status_check_on_cursormoved` to 1 and run status checking on moving a cursor.
* Set `g:alpaca_tags#max_filesize` and kill processes with a file over the max size.